### PR TITLE
Second round of fixes

### DIFF
--- a/modules/completion/corfu/config.el
+++ b/modules/completion/corfu/config.el
@@ -3,6 +3,9 @@
 (defvar +corfu-buffer-scanning-size-limit (* 1 1024 1024) ; 1 MB
   "Size limit for a buffer to be scanned by `cape-dabbrev'.")
 
+(defvar +corfu-want-C-x-bindings t
+  "Whether `C-x' is a completion prefix in Evil insert state.")
+
 ;;
 ;;; Packages
 (use-package! corfu

--- a/modules/completion/corfu/config.el
+++ b/modules/completion/corfu/config.el
@@ -42,8 +42,7 @@
   (add-to-list 'corfu-continue-commands #'+corfu-move-to-minibuffer)
 
 
-  (after! evil
-    (add-hook 'evil-insert-state-exit-hook #'corfu-quit))
+  (add-hook 'evil-insert-state-exit-hook #'corfu-quit)
 
   (when (modulep! +icons)
     (add-to-list 'corfu-margin-formatters #'nerd-icons-corfu-formatter))

--- a/modules/completion/corfu/config.el
+++ b/modules/completion/corfu/config.el
@@ -7,6 +7,13 @@
 ;;; Packages
 (use-package! corfu
   :hook (doom-first-input . global-corfu-mode)
+  :init
+  (add-hook! 'minibuffer-setup-hook
+    (defun +corfu-enable-in-minibuffer ()
+      "Enable Corfu in the minibuffer if `completion-at-point' is bound."
+      (when (where-is-internal #'completion-at-point (list (current-local-map)))
+        (setq-local corfu-echo-delay nil)
+        (corfu-mode +1))))
   :config
   (setq corfu-auto t
         corfu-auto-delay 0.1
@@ -34,12 +41,6 @@
 
   (add-to-list 'corfu-continue-commands #'+corfu-move-to-minibuffer)
 
-  (add-hook! 'minibuffer-setup-hook
-    (defun +corfu-enable-in-minibuffer ()
-      "Enable Corfu in the minibuffer if `completion-at-point' is bound."
-      (when (where-is-internal #'completion-at-point (list (current-local-map)))
-        (setq-local corfu-echo-delay nil)
-        (corfu-mode +1))))
 
   (after! evil
     (add-hook 'evil-insert-state-exit-hook #'corfu-quit))

--- a/modules/completion/corfu/config.el
+++ b/modules/completion/corfu/config.el
@@ -84,6 +84,10 @@
     ;; Set up `cape-dabbrev' options.
     (defun +dabbrev-friend-buffer-p (other-buffer)
       (< (buffer-size other-buffer) +corfu-buffer-scanning-size-limit))
+    (add-hook! (prog-mode text-mode conf-mode comint-mode minibuffer-setup
+                          eshell-mode)
+      (defun +corfu-add-cape-dabbrev-h ()
+        (add-hook 'completion-at-point-functions #'cape-dabbrev 20 t)))
     (after! dabbrev
       (setq cape-dabbrev-check-other-buffers t
             dabbrev-friend-buffer-function #'+dabbrev-friend-buffer-p
@@ -91,12 +95,7 @@
             '("^ "
               "\\(TAGS\\|tags\\|ETAGS\\|etags\\|GTAGS\\|GRTAGS\\|GPATH\\)\\(<[0-9]+>\\)?")
             dabbrev-upcase-means-case-search t)
-      (add-to-list 'dabbrev-ignored-buffer-modes 'pdf-view-mode)
-
-      (add-hook! (prog-mode text-mode conf-mode comint-mode minibuffer-setup
-                            eshell-mode)
-        (defun +corfu-add-cape-dabbrev-h ()
-          (add-hook 'completion-at-point-functions #'cape-dabbrev 20 t)))))
+      (add-to-list 'dabbrev-ignored-buffer-modes 'pdf-view-mode)))
   ;; Complete emojis :).
   (when (and (modulep! +emoji) (> emacs-major-version 28))
     (add-hook! (prog-mode conf-mode)

--- a/modules/completion/corfu/config.el
+++ b/modules/completion/corfu/config.el
@@ -49,7 +49,26 @@
 
   (when (modulep! +orderless)
     (after! orderless
-      (setq orderless-component-separator #'orderless-escapable-split-on-space))))
+      (setq orderless-component-separator #'orderless-escapable-split-on-space)))
+
+  ;; If you want to update the visual hints after completing minibuffer commands
+  ;; with Corfu and exiting, you have to do it manually.
+  (defadvice! +corfu--insert-before-exit-minibuffer-a ()
+    :before #'exit-minibuffer
+    (when (or (and (frame-live-p corfu--frame)
+                   (frame-visible-p corfu--frame))
+              (and (featurep 'corfu-terminal)
+                   (popon-live-p corfu-terminal--popon)))
+      (when (member isearch-lazy-highlight-timer timer-idle-list)
+        (apply (timer--function isearch-lazy-highlight-timer)
+               (timer--args isearch-lazy-highlight-timer)))
+      (when (member (bound-and-true-p anzu--update-timer) timer-idle-list)
+        (apply (timer--function anzu--update-timer)
+               (timer--args anzu--update-timer)))
+      (when (member (bound-and-true-p evil--ex-search-update-timer)
+                    timer-idle-list)
+        (apply (timer--function evil--ex-search-update-timer)
+               (timer--args evil--ex-search-update-timer))))))
 
 (use-package! cape
   :defer t

--- a/modules/config/default/+evil-bindings.el
+++ b/modules/config/default/+evil-bindings.el
@@ -163,14 +163,15 @@
        (:after corfu
         (:map corfu-mode-map
          :e "C-M-i" #'completion-at-point
-         (:prefix "C-x"
-          :i "C-l" #'cape-line
-          :i "C-k" #'cape-keyword
-          :i "C-f" #'cape-file
-          :i "s"   #'cape-dict
-          :i "C-s" #'yasnippet-capf
-          :i "C-n" #'cape-dabbrev
-          :i "C-p" #'cape-history)
+         (:when +corfu-want-C-x-bindings
+           (:prefix "C-x"
+            :i "C-l" #'cape-line
+            :i "C-k" #'cape-keyword
+            :i "C-f" #'cape-file
+            :i "s"   #'cape-dict
+            :i "C-s" #'yasnippet-capf
+            :i "C-n" #'cape-dabbrev
+            :i "C-p" #'cape-history))
          (:unless (modulep! :completion corfu +tng)
           :i "C-SPC" #'completion-at-point
           :n "C-SPC" (cmd! (call-interactively #'evil-insert-state)

--- a/modules/config/default/config.el
+++ b/modules/config/default/config.el
@@ -469,10 +469,10 @@ Continues comments if executed from a commented line. Consults
          (:when (modulep! :completion corfu +orderless)
           [remap completion-at-point] #'+corfu-smart-sep-toggle-escape)
          (:when (modulep! :completion corfu +tng)
-          [tab] #'corfu-next
-          "TAB" #'corfu-next
-          [backtab] #'corfu-previous
-          "S-TAB" #'corfu-previous))
+          :gi [tab] #'corfu-next
+          :gi "TAB" #'corfu-next
+          :gi [backtab] #'corfu-previous
+          :gi "S-TAB" #'corfu-previous))
         (:after corfu-popupinfo
          :map corfu-popupinfo-map
          "C-<up>" #'corfu-popupinfo-scroll-down


### PR DESCRIPTION
Hi. This is another round of fixes from after using this module for a day. I fixed the minibuffer completion behavior in -`anzu-query-replace` and other such commands but have not changed the predicate for enabling Corfu in the minibuffer. Currently, in my config, I am using
```elisp
(defun cae-corfu-enable-in-minibuffer-h ()
  (unless (or (bound-and-true-p mct--active)
              (bound-and-true-p vertico--input)
              (eq (current-local-map) read-passwd-map)
              (and (featurep 'helm-core)
                   (helm--alive-p)))
    (corfu-mode +1)))
```
which works fine for me on `ivy`, `helm`, and `vertico` but feel free to test that and let me know what you think about a more aggressive minibuffer completion after applying this PR.

Also, I added a variable to disable the `C-x` keybindings because I don't like how they override `C-x C-n` and `C-x C-p`.

After the PR is merged, I can PR an update to the README.